### PR TITLE
Add utils directory for project-wide scripts

### DIFF
--- a/utils/.keep
+++ b/utils/.keep
@@ -1,0 +1,1 @@
+# This is a placeholder file to ensure Git tracks the utils directory.

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,9 @@
+# Project Utility Scripts
+
+This directory contains general-purpose Python utility scripts for the project.
+
+## Adding New Scripts
+
+- Place your script directly in this `utils/` directory.
+- Ensure your script has a clear purpose and is well-documented.
+- If your script has external dependencies, please document them clearly, either in the script's docstring or in this README.


### PR DESCRIPTION
This commit introduces a new directory named `utils` at the root of the repository.

This directory is intended to store general-purpose Python utility scripts that can be used across the broader project.

A README.md file has been added to the `utils` directory to explain its purpose and provide basic guidelines for adding new scripts.